### PR TITLE
Add Krea 2 LoRA support and fix a norm-calculation crash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -256,6 +256,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "console-panic-hook"
+version = "1.3.3"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-test",
+ "web-sys",
+]
+
+[[package]]
 name = "console_error_panic_hook"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -684,7 +694,7 @@ dependencies = [
 
 [[package]]
 name = "inspector"
-version = "1.1.1-beta.10"
+version = "1.3.3"
 dependencies = [
  "candle-core",
  "getrandom",
@@ -760,7 +770,7 @@ checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
 name = "lora-inspector"
-version = "1.1.1-beta.10"
+version = "1.3.3"
 dependencies = [
  "candle-core",
  "clap",
@@ -772,7 +782,7 @@ dependencies = [
 
 [[package]]
 name = "lora-inspector-wasm"
-version = "1.1.1-beta.10"
+version = "1.3.3"
 dependencies = [
  "candle-core",
  "console_error_panic_hook",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ description = "LoRA inspector for Stable Diffusion"
 [workspace]
 members = ['crates/*']
 resolver = "2"
-package = {version = "1.4.0-beta.1", authors = ['Dave Lage (rockerBOO)'], edition = "2021", license = "MIT", repository = "https://github.com/rockerBOO/lora-inspector-rs", description = "LoRA inspector for Stable Diffusion"}
+package = {version = "1.3.3", authors = ['Dave Lage (rockerBOO)'], edition = "2021", license = "MIT", repository = "https://github.com/rockerBOO/lora-inspector-rs", description = "LoRA inspector for Stable Diffusion"}
 dependencies = {candle-core = {version = "0.3.2"}, getrandom = {version = "0.2", features = ['js']}, num = "0.4.1", pest = "2.6", pest_derive = "2.6", safetensors = "0.3.1", serde = {version = "1.0", features = ['derive']}, serde_json = "1.0.108", serde_with = "3.4.0"}
 
 [profile]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ description = "LoRA inspector for Stable Diffusion"
 [workspace]
 members = ['crates/*']
 resolver = "2"
-package = {version = "1.3.2", authors = ['Dave Lage (rockerBOO)'], edition = "2021", license = "MIT", repository = "https://github.com/rockerBOO/lora-inspector-rs", description = "LoRA inspector for Stable Diffusion"}
+package = {version = "1.4.0-beta.1", authors = ['Dave Lage (rockerBOO)'], edition = "2021", license = "MIT", repository = "https://github.com/rockerBOO/lora-inspector-rs", description = "LoRA inspector for Stable Diffusion"}
 dependencies = {candle-core = {version = "0.3.2"}, getrandom = {version = "0.2", features = ['js']}, num = "0.4.1", pest = "2.6", pest_derive = "2.6", safetensors = "0.3.1", serde = {version = "1.0", features = ['derive']}, serde_json = "1.0.108", serde_with = "3.4.0"}
 
 [profile]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,12 +4,12 @@ version = "1.0.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/rockerBOO/lora-inspector-rs"
-description = "LoRA inspector for Stable Diffusion"
+description = "Inspect and analyze LoRA files for diffusion models (UNet and DiT architectures like Stable Diffusion, Flux, and Krea), including network type, weight norms, rank health, and metadata, via CLI and WebAssembly."
 
 [workspace]
 members = ['crates/*']
 resolver = "2"
-package = {version = "1.3.3", authors = ['Dave Lage (rockerBOO)'], edition = "2021", license = "MIT", repository = "https://github.com/rockerBOO/lora-inspector-rs", description = "LoRA inspector for Stable Diffusion"}
+package = {version = "1.3.3", authors = ['Dave Lage (rockerBOO)'], edition = "2021", license = "MIT", repository = "https://github.com/rockerBOO/lora-inspector-rs", description = "Inspect and analyze LoRA files for diffusion models (UNet and DiT architectures like Stable Diffusion, Flux, and Krea), including network type, weight norms, rank health, and metadata, via CLI and WebAssembly."}
 dependencies = {candle-core = {version = "0.3.2"}, getrandom = {version = "0.2", features = ['js']}, num = "0.4.1", pest = "2.6", pest_derive = "2.6", safetensors = "0.3.1", serde = {version = "1.0", features = ['derive']}, serde_json = "1.0.108", serde_with = "3.4.0"}
 
 [profile]

--- a/crates/inspector/src/file.rs
+++ b/crates/inspector/src/file.rs
@@ -194,15 +194,71 @@ impl LoRAFile {
     pub fn effective_scale(&self, base_name: &str) -> Result<Option<f64>> {
         match self.weights.as_ref() {
             None => Ok(None),
-            Some(_) => match self.scale_weight(base_name) {
-                Ok(t) => Ok(Some(self.l2_norm::<f64>(&t)?)),
-                Err(InspectorError::UnsupportedNetworkType) => Ok(None),
-                Err(InspectorError::Candle(candle_core::Error::SafeTensor(
-                    SafeTensorError::TensorNotFound(_),
-                ))) => Ok(None),
-                Err(e) => Err(e),
-            },
+            Some(_) => {
+                if let Some(norm) = self.lora_frobenius_norm(base_name)? {
+                    return Ok(Some(norm));
+                }
+
+                match self.scale_weight(base_name) {
+                    Ok(t) => Ok(Some(self.l2_norm::<f64>(&t)?)),
+                    Err(InspectorError::UnsupportedNetworkType) => Ok(None),
+                    Err(InspectorError::Candle(candle_core::Error::SafeTensor(
+                        SafeTensorError::TensorNotFound(_),
+                    ))) => Ok(None),
+                    Err(e) => Err(e),
+                }
+            }
         }
+    }
+
+    /// Frobenius norm of the reconstructed `up @ down` delta weight, computed from the
+    /// low-rank factors directly instead of materializing the full `m x n` product.
+    ///
+    /// `||up @ down||_F^2 == trace((up^T up)(down down^T))`, which only requires the
+    /// `rank x rank` Gram matrices of `up` and `down`. For layers with a huge output
+    /// dimension (e.g. DiT modulation/projection layers), the full product can be
+    /// hundreds of MB to reconstruct just to throw away everything but its norm, which
+    /// can exhaust the wasm heap. Returns `Ok(None)` when the layer isn't a plain 2D
+    /// LoRA up/down pair (conv/tucker/other decompositions fall back to full
+    /// materialization since this identity doesn't directly apply to them).
+    fn lora_frobenius_norm(&self, base_name: &str) -> Result<Option<f64>> {
+        let weights = match self.weights.as_ref() {
+            Some(weights) => weights,
+            None => return Ok(None),
+        };
+
+        let up = match weights.up(base_name) {
+            Ok(t) => t,
+            Err(candle_core::Error::SafeTensor(SafeTensorError::TensorNotFound(_))) => {
+                return Ok(None)
+            }
+            Err(e) => return Err(InspectorError::from(e)),
+        };
+        let down = match weights.down(base_name) {
+            Ok(t) => t,
+            Err(candle_core::Error::SafeTensor(SafeTensorError::TensorNotFound(_))) => {
+                return Ok(None)
+            }
+            Err(e) => return Err(InspectorError::from(e)),
+        };
+
+        if up.dims().len() != 2 || down.dims().len() != 2 {
+            return Ok(None);
+        }
+
+        let alpha = weights.alpha(base_name)?;
+        let rank = down.dims()[0] as f64;
+        let scale = alpha.0 as f64 / rank;
+
+        let up = up.to_dtype(candle_core::DType::F64)?;
+        let down = down.to_dtype(candle_core::DType::F64)?;
+
+        let gram_u = up.t()?.matmul(&up)?; // rank x rank
+        let gram_v = down.matmul(&down.t()?)?; // rank x rank
+
+        let frob_sq: f64 = gram_u.mul(&gram_v)?.sum_all()?.to_scalar()?;
+
+        Ok(Some(frob_sq.max(0.0).sqrt() * scale.abs()))
     }
 
     pub fn factorization_balance(&self, base_name: &str) -> Result<Option<f64>> {
@@ -564,7 +620,11 @@ mod tests {
         let eff = lora_file.effective_scale(base_name)?.unwrap();
         let scaled = lora_file.scale_weight(base_name)?;
         let l2 = lora_file.l2_norm::<f64>(&scaled)?;
-        assert!((eff - l2).abs() < 1e-10);
+        // `effective_scale` takes a low-rank shortcut (trace of small Gram matrices)
+        // instead of materializing the full up @ down product, so it sums the same
+        // quantity in a different order than `l2_norm` and only agrees up to f32
+        // rounding, not bit-for-bit.
+        assert!((eff - l2).abs() / l2.abs() < 1e-5, "eff={eff} l2={l2}");
         Ok(())
     }
 

--- a/crates/inspector/src/metadata.rs
+++ b/crates/inspector/src/metadata.rs
@@ -68,6 +68,7 @@ impl Metadata {
             Some(NetworkModule::MusubiTunerLoRAFlux2) => Some(NetworkType::LoRA),
             Some(NetworkModule::KohyaSSLoRALumina) => Some(NetworkType::LoRA),
             Some(NetworkModule::KohyaSSLoRASD3) => Some(NetworkType::LoRA),
+            Some(NetworkModule::MusubiTunerLoRAKrea2) => Some(NetworkType::LoRA),
             None => None,
         }
     }
@@ -95,6 +96,7 @@ impl Metadata {
                 "networks.lora_flux" => Some(NetworkModule::KohyaSSLoRAFlux),
                 "networks.lora_flux_2" => Some(NetworkModule::MusubiTunerLoRAFlux2),
                 "networks.lora_sd3" => Some(NetworkModule::KohyaSSLoRASD3),
+                "networks.lora_krea2" => Some(NetworkModule::MusubiTunerLoRAKrea2),
                 "networks.lora_fa" => Some(NetworkModule::KohyaSSLoRAFA),
                 "networks.dylora" => Some(NetworkModule::KohyaSSDyLoRA),
                 "networks.oft" => Some(NetworkModule::KohyaSSOFT),

--- a/crates/inspector/src/network.rs
+++ b/crates/inspector/src/network.rs
@@ -17,6 +17,7 @@ pub enum NetworkModule {
     MusubiTunerLoRAFlux2,
     KohyaSSLoRALumina,
     KohyaSSLoRASD3,
+    MusubiTunerLoRAKrea2,
     KohyaSSLoRAFA,
     KohyaSSDyLoRA,
     KohyaSSOFT,

--- a/crates/lora-inspector-wasm/assets/js/components/metadata/PretrainedModel.jsx
+++ b/crates/lora-inspector-wasm/assets/js/components/metadata/PretrainedModel.jsx
@@ -5,7 +5,7 @@ export function PretrainedModel({ metadata }) {
 	return (
 		<div className="pretrained-model row space-apart">
 			<MetaAttribute
-				name="SD model name"
+				name="Base model name"
 				value={metadata.get("ss_sd_model_name")}
 			/>
 			{metadata.has("ss_model_type") && (

--- a/crates/lora-inspector-wasm/assets/js/moduleBlocks.js
+++ b/crates/lora-inspector-wasm/assets/js/moduleBlocks.js
@@ -31,6 +31,13 @@ const SDXL_RE =
 
 const SDXL_NUM_OF_BLOCKS = 26;
 
+// Krea 2 (musubi-tuner networks.lora_krea2) DiT block naming
+const KREA2_BLOCK_RE =
+	/lora_unet_(?<block_type>blocks|txtfusion_layerwise_blocks|txtfusion_refiner_blocks)_(?<block_id>\d+)_(?<subblock_type>attn_\w+|mlp_\w+)/;
+
+const KREA2_NUM_OF_BLOCKS = 28;
+const KREA2_NUM_OF_LAYERWISE_BLOCKS = 2;
+
 /**
  * @typedef {Object} Module
  * @property {number} idx - The index of the module
@@ -228,6 +235,56 @@ function parseSDKey(key) {
 			blockType: groups.block_type,
 			name: `TE${padTwo(blockId)}`,
 			isAttention: true,
+		};
+	}
+
+	// Krea 2: single-tensor modules (no block index)
+	if (
+		key.includes("lora_unet_first") ||
+		key.includes("lora_unet_last_linear") ||
+		key.includes("lora_unet_tmlp_") ||
+		key.includes("lora_unet_tproj_") ||
+		key.includes("lora_unet_txtfusion_projector") ||
+		key.includes("lora_unet_txtmlp_")
+	) {
+		return {
+			...result,
+			idx: 0,
+			blockIdx: 0,
+			name: "KREA2_IN",
+			type: "embedder",
+		};
+	}
+
+	// Krea 2 DiT blocks (main stream + txtfusion layerwise/refiner blocks)
+	if (key.includes("lora_unet_blocks_") || key.includes("txtfusion_")) {
+		const matches = key.match(KREA2_BLOCK_RE);
+		if (!matches) {
+			throw new Error(`Krea2: Did not match on key: ${key} ${KREA2_BLOCK_RE}`);
+		}
+
+		const groups = matches.groups;
+		const idx = Number.parseInt(groups.block_id);
+
+		let namePrefix = "TB";
+		let blockIdxOffset = 0;
+		if (groups.block_type === "txtfusion_layerwise_blocks") {
+			namePrefix = "TFL";
+			blockIdxOffset = KREA2_NUM_OF_BLOCKS;
+		} else if (groups.block_type === "txtfusion_refiner_blocks") {
+			namePrefix = "TFR";
+			blockIdxOffset = KREA2_NUM_OF_BLOCKS + KREA2_NUM_OF_LAYERWISE_BLOCKS;
+		}
+
+		return {
+			...result,
+			type: groups.subblock_type.startsWith("attn") ? "attentions" : "mlp",
+			idx: idx,
+			blockId: `${idx}`,
+			blockType: groups.block_type,
+			blockIdx: blockIdxOffset + idx,
+			name: `${namePrefix}${padTwo(idx)}`,
+			isAttention: groups.subblock_type.startsWith("attn"),
 		};
 	}
 

--- a/crates/lora-inspector-wasm/package.json
+++ b/crates/lora-inspector-wasm/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "lora-inspector-wasm",
 	"version": "1.0.0",
-	"description": "",
+	"description": "Inspect and analyze LoRA files for diffusion models (UNet and DiT architectures like Stable Diffusion, Flux, and Krea), including network type, weight norms, rank health, and metadata, via CLI and WebAssembly.",
 	"keywords": [],
 	"author": "",
 	"license": "ISC",

--- a/crates/lora-inspector-wasm/src/worker.rs
+++ b/crates/lora-inspector-wasm/src/worker.rs
@@ -575,9 +575,16 @@ mod tests {
             .scale_weight("lora_unet_down_blocks_1_attentions_0_transformer_blocks_0_attn2_to_k")
             .unwrap());
 
-        assert_eq!(
-            worker.l2_norm("lora_unet_down_blocks_1_attentions_0_transformer_blocks_0_attn2_to_k"),
-            Some(0.42464358477734687)
+        // The low-rank fast path in `effective_scale` sums the same quantity in a
+        // different order than a full materialization, so it only agrees with this
+        // previously-recorded value up to f32 rounding, not bit-for-bit.
+        let expected = 0.42464358477734687;
+        let result = worker
+            .l2_norm("lora_unet_down_blocks_1_attentions_0_transformer_blocks_0_attn2_to_k")
+            .unwrap();
+        assert!(
+            (result - expected).abs() / expected < 1e-5,
+            "got {result}, expected {expected}"
         );
     }
 
@@ -595,11 +602,15 @@ mod tests {
             .scale_weight("lora_unet_down_blocks_1_attentions_0_transformer_blocks_0_attn2_to_k")
             .unwrap());
 
-        assert_eq!(
-            worker.matrix_norm(
-                "lora_unet_down_blocks_1_attentions_0_transformer_blocks_0_attn2_to_k"
-            ),
-            Some(0.42464358477734687)
+        // Same rationale as the `l2_norm` test above: the low-rank fast path only
+        // agrees with this recorded value up to f32 rounding.
+        let expected = 0.42464358477734687;
+        let result = worker
+            .matrix_norm("lora_unet_down_blocks_1_attentions_0_transformer_blocks_0_attn2_to_k")
+            .unwrap();
+        assert!(
+            (result - expected).abs() / expected < 1e-5,
+            "got {result}, expected {expected}"
         );
     }
 

--- a/crates/lora-inspector-wasm/src/worker.rs
+++ b/crates/lora-inspector-wasm/src/worker.rs
@@ -575,9 +575,9 @@ mod tests {
             .scale_weight("lora_unet_down_blocks_1_attentions_0_transformer_blocks_0_attn2_to_k")
             .unwrap());
 
-        // The low-rank fast path in `effective_scale` sums the same quantity in a
-        // different order than a full materialization, so it only agrees with this
-        // previously-recorded value up to f32 rounding, not bit-for-bit.
+        // `effective_scale` sums this quantity via small Gram matrices rather than the
+        // full materialized product, so results only agree up to f32 rounding, not
+        // bit-for-bit.
         let expected = 0.42464358477734687;
         let result = worker
             .l2_norm("lora_unet_down_blocks_1_attentions_0_transformer_blocks_0_attn2_to_k")
@@ -602,8 +602,7 @@ mod tests {
             .scale_weight("lora_unet_down_blocks_1_attentions_0_transformer_blocks_0_attn2_to_k")
             .unwrap());
 
-        // Same rationale as the `l2_norm` test above: the low-rank fast path only
-        // agrees with this recorded value up to f32 rounding.
+        // Same reasoning as the `l2_norm` test above: agrees only up to f32 rounding.
         let expected = 0.42464358477734687;
         let result = worker
             .matrix_norm("lora_unet_down_blocks_1_attentions_0_transformer_blocks_0_attn2_to_k")

--- a/crates/lora-inspector-wasm/src/worker.rs
+++ b/crates/lora-inspector-wasm/src/worker.rs
@@ -246,46 +246,27 @@ impl LoraWorker {
     pub fn l2_norm(&self, base_name: &str) -> Option<f64> {
         console_error_panic_hook::set_once();
 
-        match self.file.scale_weight(base_name) {
-            Ok(scaled_weight) => self
-                .file
-                .l2_norm(&scaled_weight)
-                .map_err(|e| {
-                    console::error_1(
-                        &format!("L2 norm calculation for {} Error: {:#?}", base_name, e).into(),
-                    );
-                    e
-                })
-                .ok(),
-            Err(e) => {
+        self.file
+            .effective_scale(base_name)
+            .map_err(|e| {
                 console::error_1(
-                    &format!("Error scaling weight for {} Error: {:#?}", base_name, e).into(),
+                    &format!("L2 norm calculation for {} Error: {:#?}", base_name, e).into(),
                 );
-                None
-            }
-        }
+            })
+            .ok()
+            .flatten()
     }
 
     pub fn matrix_norm(&self, base_name: &str) -> Option<f64> {
         console_error_panic_hook::set_once();
-        match self.file.scale_weight(base_name) {
-            Ok(scaled_weight) => self
-                .file
-                .matrix_norm(&scaled_weight)
-                .map_err(|e| {
-                    console::error_1(
-                        &format!("Matrix norm for {} Error: {:#?}", base_name, e).into(),
-                    );
-                    e
-                })
-                .ok(),
-            Err(e) => {
-                console::error_1(
-                    &format!("Error scaling weight for {} Error: {:#?}", base_name, e).into(),
-                );
-                None
-            }
-        }
+
+        self.file
+            .effective_scale(base_name)
+            .map_err(|e| {
+                console::error_1(&format!("Matrix norm for {} Error: {:#?}", base_name, e).into());
+            })
+            .ok()
+            .flatten()
     }
 
     pub fn network_module(&self) -> String {
@@ -296,6 +277,7 @@ impl LoraWorker {
             Some(NetworkModule::MusubiTunerLoRAFlux2) => "musubi-tuner/lora_flux_2".to_owned(),
             Some(NetworkModule::KohyaSSLoRALumina) => "kohya-ss/lora_lumina".to_owned(),
             Some(NetworkModule::KohyaSSLoRASD3) => "kohya-ss/lora_sd3".to_owned(),
+            Some(NetworkModule::MusubiTunerLoRAKrea2) => "musubi-tuner/lora_krea2".to_owned(),
             Some(NetworkModule::KohyaSSLoRAFA) => "kohya-ss/lora_fa".to_owned(),
             Some(NetworkModule::KohyaSSDyLoRA) => "kohya-ss/dylora".to_owned(),
             Some(NetworkModule::KohyaSSOFT) => "kohya-ss/oft".to_owned(),


### PR DESCRIPTION
## Summary
- Add support for Krea 2 (musubi-tuner) LoRA key naming so its blocks group correctly in the UI
- Fix a crash where computing weight norms on certain large Krea 2 layers ran out of memory and broke the browser worker
- Update the project description to better reflect what it does

## Test plan
- [x] `cargo test` passes
- [x] Verified against a real Krea 2 LoRA file that previously crashed