### PR TITLE
Fix invalid malloc request crash on large LoRA file upload

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -257,7 +257,7 @@ dependencies = [
 
 [[package]]
 name = "console-panic-hook"
-version = "1.3.3"
+version = "1.5.0"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -694,7 +694,7 @@ dependencies = [
 
 [[package]]
 name = "inspector"
-version = "1.3.3"
+version = "1.5.0"
 dependencies = [
  "candle-core",
  "getrandom",
@@ -770,7 +770,7 @@ checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
 name = "lora-inspector"
-version = "1.3.3"
+version = "1.5.0"
 dependencies = [
  "candle-core",
  "clap",
@@ -782,7 +782,7 @@ dependencies = [
 
 [[package]]
 name = "lora-inspector-wasm"
-version = "1.3.3"
+version = "1.5.0"
 dependencies = [
  "candle-core",
  "console_error_panic_hook",

--- a/crates/inspector/src/file.rs
+++ b/crates/inspector/src/file.rs
@@ -19,6 +19,13 @@ pub struct LayerScale {
     pub is_outlier: bool,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TensorInfo {
+    pub name: String,
+    pub dtype: String,
+    pub shape: Vec<usize>,
+}
+
 /// LoRA file buffer
 #[derive(Debug)]
 pub struct LoRAFile {
@@ -26,6 +33,7 @@ pub struct LoRAFile {
     weights: Option<BufferedLoRAWeight>,
     scaled_weights: HashMap<String, candle_core::Tensor>,
     metadata: Option<Metadata>,
+    header: Option<crate::header::HeaderIndex>,
 }
 
 // const WEIGHT_NOT_LOADED: &str = "Weight not loaded properly";
@@ -33,6 +41,7 @@ pub struct LoRAFile {
 impl LoRAFile {
     pub fn new_from_buffer(buffer: &[u8], filename: &str, device: &Device) -> LoRAFile {
         let metadata = Metadata::new_from_buffer(buffer).map_err(|e| e.to_string());
+        let header = crate::header::parse_header(buffer).ok().map(|(h, _)| h);
 
         LoRAFile {
             filename: filename.to_string(),
@@ -41,7 +50,24 @@ impl LoRAFile {
                 .unwrap_or_else(|_| None),
             scaled_weights: HashMap::new(),
             metadata: metadata.map(Some).unwrap_or_else(|_| None),
+            header,
         }
+    }
+
+    /// Builds a `LoRAFile` from just the safetensors header — no tensor payload
+    /// bytes required. `is_tensors_loaded()` will be `false`; call
+    /// `reload_weights` with the full file buffer before any weight-value
+    /// operation (`scale_weight`, `effective_scale`, `rank_metrics`, ...).
+    pub fn new_from_header_buffer(buffer: &[u8], filename: &str) -> Result<LoRAFile> {
+        let (header, meta_map) = crate::header::parse_header(buffer)?;
+
+        Ok(LoRAFile {
+            filename: filename.to_string(),
+            weights: None,
+            scaled_weights: HashMap::new(),
+            metadata: Some(Metadata { metadata: meta_map }),
+            header: Some(header),
+        })
     }
 
     pub fn unload(&mut self) {
@@ -64,30 +90,30 @@ impl LoRAFile {
     }
 
     pub fn unet_keys(&self) -> Vec<String> {
-        self.weights
+        self.header
             .as_ref()
-            .map(|weights| weights.unet_keys())
+            .map(|h| h.unet_keys())
             .unwrap_or_default()
     }
 
     pub fn text_encoder_keys(&self) -> Vec<String> {
-        self.weights
+        self.header
             .as_ref()
-            .map(|weights| weights.text_encoder_keys())
+            .map(|h| h.text_encoder_keys())
             .unwrap_or_default()
     }
 
     pub fn weight_keys(&self) -> Vec<String> {
-        self.weights
+        self.header
             .as_ref()
-            .map(|weights| weights.weight_keys())
+            .map(|h| h.weight_keys())
             .unwrap_or_default()
     }
 
     pub fn alpha_keys(&self) -> Vec<String> {
-        self.weights
+        self.header
             .as_ref()
-            .map(|weights| weights.alpha_keys())
+            .map(|h| h.alpha_keys())
             .unwrap_or_default()
     }
 
@@ -99,29 +125,37 @@ impl LoRAFile {
     }
 
     pub fn dims(&self) -> HashSet<usize> {
-        self.weights
-            .as_ref()
-            .map(|weights| weights.dims())
-            .unwrap_or_default()
+        self.header.as_ref().map(|h| h.dims()).unwrap_or_default()
     }
 
     pub fn precision(&self) -> Option<weight::DType> {
-        self.weights
-            .as_ref()
-            .and_then(|weights| weights.precision())
+        self.header.as_ref().and_then(|h| h.precision())
     }
 
     pub fn keys(&self) -> Vec<String> {
-        self.weights
-            .as_ref()
-            .map(|weights| weights.keys())
-            .unwrap_or_default()
+        self.header.as_ref().map(|h| h.keys()).unwrap_or_default()
     }
 
     pub fn base_names(&self) -> Vec<String> {
-        self.weights
+        self.header
             .as_ref()
-            .map(|weights| weights.base_names())
+            .map(|h| h.base_names())
+            .unwrap_or_default()
+    }
+
+    pub fn tensor_info(&self) -> Vec<TensorInfo> {
+        self.header
+            .as_ref()
+            .map(|h| {
+                h.tensor_info()
+                    .into_iter()
+                    .map(|(name, dtype, shape)| TensorInfo {
+                        name,
+                        dtype: dtype.to_string(),
+                        shape,
+                    })
+                    .collect()
+            })
             .unwrap_or_default()
     }
 
@@ -146,9 +180,9 @@ impl LoRAFile {
     }
 
     pub fn format(&self) -> weight::LoRAFormat {
-        self.weights
+        self.header
             .as_ref()
-            .map(|weights| weights.format())
+            .map(|h| h.format())
             .unwrap_or(weight::LoRAFormat::Kohya)
     }
 
@@ -712,6 +746,54 @@ mod tests {
         assert_eq!(outliers, vec![false, false, false, false, true]);
         assert!((median - 1.0).abs() < 1e-10);
         assert!((threshold - 1.5).abs() < 1e-10);
+    }
+
+    fn header_only_bytes(buffer: &[u8]) -> &[u8] {
+        let mut len_bytes = [0u8; 8];
+        len_bytes.copy_from_slice(&buffer[0..8]);
+        let header_len = u64::from_le_bytes(len_bytes) as usize;
+        &buffer[0..8 + header_len]
+    }
+
+    #[test]
+    fn header_only_load_exposes_keys_without_weights() -> crate::Result<()> {
+        let buffer = load_test_file()?;
+        let lora_file =
+            LoRAFile::new_from_header_buffer(header_only_bytes(&buffer), "boo.safetensors")?;
+
+        assert!(!lora_file.is_tensors_loaded());
+        assert!(!lora_file.keys().is_empty());
+        assert!(!lora_file.base_names().is_empty());
+        assert!(!lora_file.unet_keys().is_empty());
+        assert!(!lora_file.tensor_info().is_empty());
+
+        Ok(())
+    }
+
+    #[test]
+    fn header_only_load_keys_match_full_buffer_load() -> crate::Result<()> {
+        let buffer = load_test_file()?;
+        let header_file =
+            LoRAFile::new_from_header_buffer(header_only_bytes(&buffer), "boo.safetensors")?;
+        let full_file = LoRAFile::new_from_buffer(&buffer, "boo.safetensors", &Device::Cpu);
+
+        let mut header_keys = header_file.keys();
+        let mut full_keys = full_file.keys();
+        header_keys.sort();
+        full_keys.sort();
+        assert_eq!(header_keys, full_keys);
+
+        assert_eq!(header_file.dims(), full_file.dims());
+        assert_eq!(header_file.format(), full_file.format());
+        assert_eq!(header_file.precision(), full_file.precision());
+
+        Ok(())
+    }
+
+    #[test]
+    fn header_only_load_rejects_truncated_buffer() {
+        let result = LoRAFile::new_from_header_buffer(&[1_u8, 2, 3], "boo.safetensors");
+        assert!(result.is_err());
     }
 
     #[test]

--- a/crates/inspector/src/file.rs
+++ b/crates/inspector/src/file.rs
@@ -8,7 +8,7 @@ use crate::{
     network::NetworkType,
     norms::{l1, l2, matrix_norm},
     svd,
-    weight::{self, BufferedLoRAWeight, Weight, WeightKey},
+    weight::{self, BufferedLoRAWeight, Weight},
     InspectorError, Result,
 };
 

--- a/crates/inspector/src/header.rs
+++ b/crates/inspector/src/header.rs
@@ -1,0 +1,275 @@
+use std::collections::{HashMap, HashSet};
+
+use crate::weight::{get_base_name, is_peft, DType, LoRAFormat};
+use crate::InspectorError;
+
+/// A tensor's shape/dtype as recorded in the safetensors header, without its
+/// payload bytes.
+#[derive(Debug, Clone)]
+pub struct TensorEntry {
+    pub dtype: DType,
+    pub shape: Vec<usize>,
+}
+
+/// An index of every tensor's name, dtype and shape parsed from a safetensors
+/// header, independent of whether the tensor payload bytes are resident anywhere.
+#[derive(Debug, Clone)]
+pub struct HeaderIndex {
+    tensors: HashMap<String, TensorEntry>,
+    format: LoRAFormat,
+}
+
+impl HeaderIndex {
+    pub fn keys(&self) -> Vec<String> {
+        self.tensors.keys().cloned().collect()
+    }
+
+    pub fn keys_by_key(&self, key: &str) -> Vec<String> {
+        self.tensors
+            .keys()
+            .filter(|k| k.contains(key))
+            .cloned()
+            .collect()
+    }
+
+    pub fn weight_keys(&self) -> Vec<String> {
+        let hada = &mut self.keys_by_key("hada_w1");
+        let lokr = &mut self.keys_by_key("lokr_w1");
+        let oft_diag = &mut self.keys_by_key("oft_diag");
+        let oft_blocks = &mut self.keys_by_key("oft_block");
+        let glora_a1 = &mut self.keys_by_key("a1");
+        let glora_b1 = &mut self.keys_by_key("b1");
+        let glora_a2 = &mut self.keys_by_key("a2");
+        let glora_b2 = &mut self.keys_by_key("b1");
+        let mut keys = self.keys_by_key("weight");
+        keys.append(hada);
+        keys.append(lokr);
+        keys.append(oft_diag);
+        keys.append(oft_blocks);
+        keys.append(glora_a1);
+        keys.append(glora_b1);
+        keys.append(glora_a2);
+        keys.append(glora_b2);
+
+        keys
+    }
+
+    pub fn unet_keys(&self) -> Vec<String> {
+        self.keys_by_key("lora_unet")
+    }
+
+    pub fn text_encoder_keys(&self) -> Vec<String> {
+        self.keys_by_key("lora_te")
+    }
+
+    pub fn alpha_keys(&self) -> Vec<String> {
+        self.keys_by_key("alpha")
+    }
+
+    pub fn base_names(&self) -> Vec<String> {
+        self.weight_keys()
+            .iter()
+            .map(|name| get_base_name(name))
+            .collect::<HashSet<String>>()
+            .into_iter()
+            .collect()
+    }
+
+    pub fn dims(&self) -> HashSet<usize> {
+        self.tensors
+            .iter()
+            .filter_map(|(k, e)| {
+                if k.contains("lora_down")
+                    || k.contains("hada_w1_b")
+                    || k.contains("lokr_w1")
+                    || k.contains("b1.weight")
+                    || k.contains("lora_A")
+                {
+                    e.shape.first().copied()
+                } else if k.contains("oft_diag") || k.contains("oft_blocks") {
+                    e.shape.last().copied()
+                } else {
+                    None
+                }
+            })
+            .collect()
+    }
+
+    pub fn precision(&self) -> Option<DType> {
+        self.tensors
+            .iter()
+            .filter(|(k, _)| !k.contains("alpha"))
+            .collect::<Vec<_>>()
+            .first()
+            .map(|(_, e)| e.dtype)
+    }
+
+    pub fn format(&self) -> LoRAFormat {
+        self.format
+    }
+
+    /// `(name, dtype, shape)` for every tensor in the file, sorted by name for a
+    /// stable UI ordering.
+    pub fn tensor_info(&self) -> Vec<(String, DType, Vec<usize>)> {
+        let mut info: Vec<_> = self
+            .tensors
+            .iter()
+            .map(|(name, e)| (name.clone(), e.dtype, e.shape.clone()))
+            .collect();
+        info.sort_by(|a, b| a.0.cmp(&b.0));
+        info
+    }
+}
+
+/// Parses only the safetensors header — the 8-byte little-endian length prefix
+/// followed by that many bytes of header JSON — without requiring the tensor
+/// payload bytes to be present. `buffer` only needs to contain the first
+/// `8 + header_len` bytes of the file; anything beyond that is ignored.
+pub fn parse_header(
+    buffer: &[u8],
+) -> crate::Result<(HeaderIndex, Option<HashMap<String, String>>)> {
+    if buffer.len() < 8 {
+        return Err(InspectorError::Msg(
+            "buffer too small to contain a safetensors header".to_string(),
+        ));
+    }
+
+    let mut len_bytes = [0u8; 8];
+    len_bytes.copy_from_slice(&buffer[0..8]);
+    let header_len = u64::from_le_bytes(len_bytes) as usize;
+
+    let stop = 8usize
+        .checked_add(header_len)
+        .ok_or_else(|| InspectorError::Msg("safetensors header length overflow".to_string()))?;
+    if stop > buffer.len() {
+        return Err(InspectorError::Msg(
+            "buffer does not contain the full safetensors header JSON".to_string(),
+        ));
+    }
+
+    let json_str = std::str::from_utf8(&buffer[8..stop])
+        .map_err(|_| InspectorError::Msg("safetensors header is not valid UTF-8".to_string()))?;
+    let metadata: safetensors::tensor::Metadata = serde_json::from_str(json_str)?;
+
+    let sample_keys: Vec<String> = metadata.tensors().keys().take(10).cloned().collect();
+    let format = if is_peft(sample_keys) {
+        LoRAFormat::Peft
+    } else {
+        LoRAFormat::Kohya
+    };
+
+    let tensors = metadata
+        .tensors()
+        .into_iter()
+        .map(|(name, info)| {
+            (
+                name,
+                TensorEntry {
+                    dtype: info.dtype.into(),
+                    shape: info.shape.clone(),
+                },
+            )
+        })
+        .collect();
+
+    Ok((HeaderIndex { tensors, format }, metadata.metadata().clone()))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Read;
+    use std::{fs::File, io};
+
+    use candle_core::Device;
+
+    use crate::weight::BufferedLoRAWeight;
+
+    use super::*;
+
+    fn load_test_file() -> Result<Vec<u8>, io::Error> {
+        let filename = "boo.safetensors";
+        let mut f = File::open(filename)?;
+        let mut data = vec![];
+        f.read_to_end(&mut data)?;
+        Ok(data)
+    }
+
+    fn header_only_bytes(buffer: &[u8]) -> &[u8] {
+        let mut len_bytes = [0u8; 8];
+        len_bytes.copy_from_slice(&buffer[0..8]);
+        let header_len = u64::from_le_bytes(len_bytes) as usize;
+        &buffer[0..8 + header_len]
+    }
+
+    #[test]
+    fn parse_header_rejects_buffer_smaller_than_length_prefix() {
+        let result = parse_header(&[1_u8, 2, 3]);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn parse_header_rejects_truncated_header_json() {
+        let buffer = load_test_file().unwrap();
+        // 20 bytes is past the 8-byte length prefix but short of the real header JSON.
+        let result = parse_header(&buffer[0..20]);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn parse_header_works_with_header_only_buffer() {
+        let buffer = load_test_file().unwrap();
+        let (header, meta) = parse_header(header_only_bytes(&buffer)).unwrap();
+
+        assert!(!header.keys().is_empty());
+        assert!(meta.is_some());
+    }
+
+    #[test]
+    fn header_index_matches_buffered_weight_for_boo_file() {
+        let buffer = load_test_file().unwrap();
+        let (header, _meta) = parse_header(&buffer).unwrap();
+
+        let buffered = BufferedLoRAWeight::new(buffer.clone(), &Device::Cpu).unwrap();
+
+        use crate::weight::{Weight, WeightKey};
+
+        let mut header_keys = header.keys();
+        let mut buffered_keys = buffered.keys();
+        header_keys.sort();
+        buffered_keys.sort();
+        assert_eq!(header_keys, buffered_keys);
+
+        assert_eq!(header.unet_keys().len(), buffered.unet_keys().len());
+        assert_eq!(
+            header.text_encoder_keys().len(),
+            buffered.text_encoder_keys().len()
+        );
+        assert_eq!(header.dims(), buffered.dims());
+        assert_eq!(header.precision(), buffered.precision());
+        assert_eq!(header.format(), buffered.format());
+
+        let mut header_base_names = header.base_names();
+        let mut buffered_base_names = buffered.base_names();
+        header_base_names.sort();
+        buffered_base_names.sort();
+        assert_eq!(header_base_names, buffered_base_names);
+    }
+
+    #[test]
+    fn tensor_info_is_non_empty_and_sorted_by_name() {
+        let buffer = load_test_file().unwrap();
+        let (header, _meta) = parse_header(&buffer).unwrap();
+
+        let info = header.tensor_info();
+        assert!(!info.is_empty());
+
+        let mut names: Vec<&String> = info.iter().map(|(name, _, _)| name).collect();
+        let sorted = {
+            let mut n = names.clone();
+            n.sort();
+            n
+        };
+        assert_eq!(names, sorted);
+        names.clear(); // silence unused mut warning path in some rustc versions
+    }
+}

--- a/crates/inspector/src/header.rs
+++ b/crates/inspector/src/header.rs
@@ -224,7 +224,7 @@ mod tests {
         let too_big: u64 = 200_000_000;
         buffer[0..8].copy_from_slice(&too_big.to_le_bytes());
         let result = parse_header(&buffer);
-        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("exceeds maximum"));
     }
 
     #[test]

--- a/crates/inspector/src/header.rs
+++ b/crates/inspector/src/header.rs
@@ -3,6 +3,11 @@ use std::collections::{HashMap, HashSet};
 use crate::weight::{get_base_name, is_peft, DType, LoRAFormat};
 use crate::InspectorError;
 
+/// Matches the upstream `safetensors` crate's own sanity bound on header size
+/// (`safetensors::tensor::MAX_HEADER_SIZE`), enforced here as defense in depth
+/// since this module intentionally bypasses `SafeTensors::read_metadata`.
+const MAX_HEADER_SIZE: usize = 100_000_000;
+
 /// A tensor's shape/dtype as recorded in the safetensors header, without its
 /// payload bytes.
 #[derive(Debug, Clone)]
@@ -138,6 +143,12 @@ pub fn parse_header(
     len_bytes.copy_from_slice(&buffer[0..8]);
     let header_len = u64::from_le_bytes(len_bytes) as usize;
 
+    if header_len > MAX_HEADER_SIZE {
+        return Err(InspectorError::Msg(format!(
+            "safetensors header length {header_len} exceeds maximum of {MAX_HEADER_SIZE} bytes"
+        )));
+    }
+
     let stop = 8usize
         .checked_add(header_len)
         .ok_or_else(|| InspectorError::Msg("safetensors header length overflow".to_string()))?;
@@ -204,6 +215,15 @@ mod tests {
     #[test]
     fn parse_header_rejects_buffer_smaller_than_length_prefix() {
         let result = parse_header(&[1_u8, 2, 3]);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn parse_header_rejects_header_len_over_max_header_size() {
+        let mut buffer = vec![0u8; 16];
+        let too_big: u64 = 200_000_000;
+        buffer[0..8].copy_from_slice(&too_big.to_le_bytes());
+        let result = parse_header(&buffer);
         assert!(result.is_err());
     }
 

--- a/crates/inspector/src/lib.rs
+++ b/crates/inspector/src/lib.rs
@@ -11,6 +11,7 @@ use wasm_bindgen::JsValue;
 pub struct KeyParser;
 
 pub mod file;
+mod header;
 pub mod metadata;
 pub mod network;
 pub mod norms;

--- a/crates/inspector/src/metadata.rs
+++ b/crates/inspector/src/metadata.rs
@@ -19,6 +19,13 @@ impl Metadata {
         )
     }
 
+    /// Builds `Metadata` from just the safetensors header (see
+    /// `crate::header::parse_header`), without requiring tensor payload bytes.
+    pub fn new_from_header_buffer(buffer: &[u8]) -> crate::Result<Metadata> {
+        let (_header, meta_map) = crate::header::parse_header(buffer)?;
+        Ok(Metadata { metadata: meta_map })
+    }
+
     pub fn metadata_size(&self) -> usize {
         self.metadata.as_ref().map_or(0, |m| m.len())
     }

--- a/crates/inspector/src/weight.rs
+++ b/crates/inspector/src/weight.rs
@@ -736,16 +736,25 @@ impl BufferedLoRAWeight {
 }
 
 pub trait WeightKey {
+    /// Correctness reference `HeaderIndex` is tested against in `header.rs`'s
+    /// `header_index_matches_buffered_weight_for_boo_file` test; not called
+    /// from non-test code since the header-based migration.
+    #[cfg_attr(not(test), allow(dead_code))]
     fn keys(&self) -> Vec<String>;
     fn keys_by_key(&self, key: &str) -> Vec<String>;
     #[allow(dead_code)]
     fn up_keys(&self) -> Vec<String>;
     #[allow(dead_code)]
     fn down_keys(&self) -> Vec<String>;
+    #[cfg_attr(not(test), allow(dead_code))]
     fn unet_keys(&self) -> Vec<String>;
+    #[cfg_attr(not(test), allow(dead_code))]
     fn text_encoder_keys(&self) -> Vec<String>;
+    #[cfg_attr(not(test), allow(dead_code))]
     fn weight_keys(&self) -> Vec<String>;
+    #[allow(dead_code)]
     fn alpha_keys(&self) -> Vec<String>;
+    #[cfg_attr(not(test), allow(dead_code))]
     fn base_names(&self) -> Vec<String>;
 }
 
@@ -757,7 +766,12 @@ pub trait Weight {
 
     fn get(&self, key: &str) -> Result<Tensor, candle_core::Error>;
 
+    /// Correctness reference `HeaderIndex` is tested against in `header.rs`'s
+    /// `header_index_matches_buffered_weight_for_boo_file` test; not called
+    /// from non-test code since the header-based migration.
+    #[cfg_attr(not(test), allow(dead_code))]
     fn format(&self) -> LoRAFormat;
+    #[cfg_attr(not(test), allow(dead_code))]
     fn precision(&self) -> Option<DType>;
     fn scale_lora_weight(&self, base_name: &str) -> Result<Tensor, candle_core::Error>;
     fn scale_glora_weights(&self, base_name: &str) -> Result<Tensor, candle_core::Error>;
@@ -772,6 +786,7 @@ pub trait Weight {
     fn alphas(&self) -> HashSet<Alpha>;
     #[allow(dead_code)]
     fn dora_scale(&self, key: &str) -> Result<Tensor, candle_core::Error>;
+    #[cfg_attr(not(test), allow(dead_code))]
     fn dims(&self) -> HashSet<usize>;
     #[allow(dead_code)]
     fn shapes(&self) -> HashMap<String, Vec<usize>>;

--- a/crates/inspector/src/weight.rs
+++ b/crates/inspector/src/weight.rs
@@ -18,7 +18,7 @@ use crate::tensor::kron;
 //   Load weights only when required
 // LoRAWeight
 
-fn is_peft(keys: Vec<String>) -> bool {
+pub(crate) fn is_peft(keys: Vec<String>) -> bool {
     keys.into_iter()
         .take(10)
         .any(|k| k.contains("lora_A") || k.contains("lora_B"))

--- a/crates/lora-inspector-wasm/assets/js/components/layout/Main.jsx
+++ b/crates/lora-inspector-wasm/assets/js/components/layout/Main.jsx
@@ -15,14 +15,12 @@ import { LRScheduler } from "../training/LRScheduler.jsx";
 import { Optimizer } from "../training/Optimizer.jsx";
 import { WaveletLoss } from "../training/WaveletLoss.jsx";
 import { MetaAttribute } from "../ui/MetaAttribute.jsx";
-import { Headline } from "./Headline.jsx";
 import { Section } from "./Section.jsx";
 
 export function Main({ metadata, filename, worker }) {
 	if (!metadata) {
 		return (
 			<main>
-				<Headline filename={filename} />
 				<div className="row space-apart">
 					<LoRANetwork
 						metadata={metadata}

--- a/crates/lora-inspector-wasm/assets/js/components/network/LoRANetwork.jsx
+++ b/crates/lora-inspector-wasm/assets/js/components/network/LoRANetwork.jsx
@@ -3,19 +3,12 @@ import { trySyncMessage } from "../../message.js";
 import { MetaAttribute } from "../ui/MetaAttribute.jsx";
 
 export function LoRANetwork({ metadata, filename, worker }) {
-	const [alphas, setAlphas] = useState([
-		metadata?.get("ss_network_alpha") ?? undefined,
-	]);
+	const alphas = [metadata?.get("ss_network_alpha") ?? undefined];
 	const [dims, setDims] = useState([
 		metadata?.get("ss_network_dim") ?? undefined,
 	]);
 
 	useEffect(() => {
-		trySyncMessage({ messageType: "alphas", name: filename }, worker).then(
-			(resp) => {
-				setAlphas(resp.alphas);
-			},
-		);
 		trySyncMessage({ messageType: "dims", name: filename }, worker).then(
 			(resp) => {
 				setDims(resp.dims);

--- a/crates/lora-inspector-wasm/assets/js/worker.js
+++ b/crates/lora-inspector-wasm/assets/js/worker.js
@@ -32,32 +32,55 @@ function clearIdleTimer(name) {
 	}
 }
 
+async function readHeaderBytes(file) {
+	const lengthBuffer = await file.slice(0, 8).arrayBuffer();
+	const headerLen = Number(new DataView(lengthBuffer).getBigUint64(0, true));
+	const headerBuffer = await file.slice(0, 8 + headerLen).arrayBuffer();
+	return new Uint8Array(headerBuffer);
+}
+
 async function reloadWorker(file) {
-	const buffer = await readFile(file);
+	const buffer = await readHeaderBytes(file);
 	addWorker(file.name, new LoraWorkerClass(buffer, file.name));
 }
 
-async function ensureLoaded(name) {
+// Ensures the LoraWorker object exists (reconstructing it from just the file's
+// header if it was GC'd), without requiring tensor weight bytes to be loaded.
+async function ensureHeaderLoaded(name) {
 	const loraWorker = loraWorkers.get(name);
 	const file = files.get(name);
 
 	if (!loraWorker) {
-		// Worker was fully freed — reconstruct from scratch
 		if (!file) throw new Error(`Cannot reload worker ${name}: file not found`);
 		await reloadWorker(file);
-	} else if (!loraWorker.is_tensors_loaded()) {
-		// Worker alive but weights unloaded (idle timeout) — reload weights only, metadata stays
-		if (!file)
-			throw new Error(`Cannot reload weights for ${name}: file not found`);
-		const buffer = await readFile(file);
-		loraWorker.reload_from_buffer(buffer);
 	}
 
 	setIdleTimer(name);
 }
 
+// Ensures the LoraWorker object exists AND its tensor weight bytes are loaded
+// (the full file, via readFile) — required before any weight-value operation
+// (scale_weight, norms, rank_metrics, effective_scale, alphas, ...).
+async function ensureWeightsLoaded(name) {
+	await ensureHeaderLoaded(name);
+
+	const loraWorker = getWorker(name);
+	if (!loraWorker.is_tensors_loaded()) {
+		const file = files.get(name);
+		if (!file)
+			throw new Error(`Cannot reload weights for ${name}: file not found`);
+		const buffer = await readFile(file);
+		loraWorker.reload_from_buffer(buffer);
+	}
+}
+
 async function withWorker(name, fn) {
-	await ensureLoaded(name);
+	await ensureHeaderLoaded(name);
+	return fn(getWorker(name));
+}
+
+async function withWeights(name, fn) {
+	await ensureWeightsLoaded(name);
 	return fn(getWorker(name));
 }
 
@@ -192,6 +215,15 @@ async function init_wasm_in_worker() {
 			});
 		} else if (e.data.messageType === "weight_keys") {
 			getWeightKeys(e);
+		} else if (e.data.messageType === "tensor_info") {
+			getTensorInfo(e).then((tensorInfo) => {
+				if (e.data.reply) {
+					self.postMessage({
+						messageType: "tensor_info",
+						tensorInfo,
+					});
+				}
+			});
 		} else if (e.data.messageType === "keys") {
 			getKeys(e).then((keys) => {
 				if (e.data.reply) {
@@ -390,7 +422,7 @@ async function readFile(file) {
 }
 
 async function loadWorker(file, worker) {
-	const buffer = await readFile(file);
+	const buffer = await readHeaderBytes(file);
 
 	try {
 		const loraWorker = addWorker(file.name, new worker(buffer, file.name));
@@ -466,9 +498,13 @@ async function getBaseNames(e) {
 	return withWorker(e.data.name, (w) => w.base_names());
 }
 
+async function getTensorInfo(e) {
+	return withWorker(e.data.name, (w) => w.tensor_info());
+}
+
 async function getNorms(e) {
 	const baseName = e.data.baseName;
-	return withWorker(e.data.name, (w) => {
+	return withWeights(e.data.name, (w) => {
 		try {
 			return [
 				w.norms(baseName, [
@@ -490,9 +526,9 @@ async function getNorms(e) {
 }
 
 async function getL2Norms(e) {
-	await ensureLoaded(e.data.name);
+	await ensureWeightsLoaded(e.data.name);
 	clearIdleTimer(e.data.name); // prevent idle timeout from firing during long batch loop
-	const loraWorker = getWorker(e.data.name); // held across loop — ensureLoaded already called
+	const loraWorker = getWorker(e.data.name); // held across loop — ensureWeightsLoaded already called
 
 	const baseNames = loraWorker.base_names();
 	const totalCount = baseNames.length;
@@ -615,7 +651,7 @@ async function getAlphaKeys(e) {
 }
 
 async function getAlphas(e) {
-	return withWorker(e.data.name, (w) =>
+	return withWeights(e.data.name, (w) =>
 		Array.from(w.alphas()).sort((a, b) => a - b),
 	);
 }
@@ -629,7 +665,7 @@ async function getRankStabilized(e) {
 }
 
 async function getDoraScales(e) {
-	return withWorker(e.data.name, (w) =>
+	return withWeights(e.data.name, (w) =>
 		Array.from(w.doraScales()).sort((a, b) => a > b),
 	);
 }
@@ -654,16 +690,16 @@ async function getNetworkType(e) {
 
 async function getEffectiveScale(e) {
 	const baseName = e.data.baseName;
-	return withWorker(e.data.name, (w) => w.effective_scale(baseName));
+	return withWeights(e.data.name, (w) => w.effective_scale(baseName));
 }
 
 async function getEffectiveScalesAll(e) {
-	return withWorker(e.data.name, (w) => w.effective_scales_all());
+	return withWeights(e.data.name, (w) => w.effective_scales_all());
 }
 
 async function getRankMetrics(e) {
 	const baseName = e.data.baseName;
-	return withWorker(e.data.name, (w) => {
+	return withWeights(e.data.name, (w) => {
 		try {
 			const metrics = w.rank_metrics(baseName);
 			return [metrics, undefined];

--- a/crates/lora-inspector-wasm/assets/js/worker.js
+++ b/crates/lora-inspector-wasm/assets/js/worker.js
@@ -6,6 +6,11 @@ const files = new Map();
 // loraWorkers are specific objects that manage the LoRA file, buffer, and inspection.
 const loraWorkers = new Map();
 
+// In-flight ensureWeightsLoaded() promises, keyed by file name, so concurrent
+// weight-value requests for the same file share a single full-file read
+// instead of each triggering their own.
+const weightLoadPromises = new Map();
+
 let LoraWorkerClass = null;
 const IDLE_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
 const idleTimers = new Map();
@@ -32,9 +37,16 @@ function clearIdleTimer(name) {
 	}
 }
 
+const MAX_HEADER_SIZE = 100_000_000;
+
 async function readHeaderBytes(file) {
 	const lengthBuffer = await file.slice(0, 8).arrayBuffer();
 	const headerLen = Number(new DataView(lengthBuffer).getBigUint64(0, true));
+	if (headerLen > MAX_HEADER_SIZE) {
+		throw new Error(
+			`safetensors header length ${headerLen} exceeds maximum of ${MAX_HEADER_SIZE} bytes — file may not be a valid safetensors file`,
+		);
+	}
 	const headerBuffer = await file.slice(0, 8 + headerLen).arrayBuffer();
 	return new Uint8Array(headerBuffer);
 }
@@ -65,12 +77,26 @@ async function ensureWeightsLoaded(name) {
 	await ensureHeaderLoaded(name);
 
 	const loraWorker = getWorker(name);
-	if (!loraWorker.is_tensors_loaded()) {
-		const file = files.get(name);
-		if (!file)
-			throw new Error(`Cannot reload weights for ${name}: file not found`);
-		const buffer = await readFile(file);
-		loraWorker.reload_from_buffer(buffer);
+	if (loraWorker.is_tensors_loaded()) {
+		return;
+	}
+
+	let loadPromise = weightLoadPromises.get(name);
+	if (!loadPromise) {
+		loadPromise = (async () => {
+			const file = files.get(name);
+			if (!file)
+				throw new Error(`Cannot reload weights for ${name}: file not found`);
+			const buffer = await readFile(file);
+			loraWorker.reload_from_buffer(buffer);
+		})();
+		weightLoadPromises.set(name, loadPromise);
+	}
+
+	try {
+		await loadPromise;
+	} finally {
+		weightLoadPromises.delete(name);
 	}
 }
 

--- a/crates/lora-inspector-wasm/assets/js/worker.js
+++ b/crates/lora-inspector-wasm/assets/js/worker.js
@@ -96,7 +96,12 @@ async function ensureWeightsLoaded(name) {
 	try {
 		await loadPromise;
 	} finally {
-		weightLoadPromises.delete(name);
+		// Only remove the entry this call started/observed -- a failed load's
+		// finally can otherwise race a newer retry's finally and delete its
+		// still-in-flight promise instead of its own.
+		if (weightLoadPromises.get(name) === loadPromise) {
+			weightLoadPromises.delete(name);
+		}
 	}
 }
 

--- a/crates/lora-inspector-wasm/src/worker.rs
+++ b/crates/lora-inspector-wasm/src/worker.rs
@@ -26,13 +26,20 @@ impl fmt::Display for LoraWorker {
 #[wasm_bindgen]
 impl LoraWorker {
     #[wasm_bindgen(constructor)]
+    /// `buffer` must contain at least the safetensors header: the 8-byte
+    /// little-endian length prefix plus that many bytes of header JSON. Tensor
+    /// payload bytes are not required here — call `reload_from_buffer` with the
+    /// full file later to load weight values.
     pub fn new_from_buffer(buffer: &[u8], filename: &str) -> Result<LoraWorker, String> {
-        // panic::set_hook(Box::new(console_panic_hook::hook));
         console_error_panic_hook::set_once();
-        let metadata = Metadata::new_from_buffer(buffer).map_err(|e| e.to_string());
-        let file = LoRAFile::new_from_buffer(buffer, filename, &candle_core::Device::Cpu);
+        let metadata = Metadata::new_from_header_buffer(buffer).map_err(|e| e.to_string());
+        let file = LoRAFile::new_from_header_buffer(buffer, filename).map_err(|e| e.to_string());
 
-        metadata.map(|metadata| LoraWorker { metadata, file })
+        match (metadata, file) {
+            (Ok(metadata), Ok(file)) => Ok(LoraWorker { metadata, file }),
+            (Err(e), _) => Err(e),
+            (_, Err(e)) => Err(e),
+        }
     }
 
     pub fn unload(&mut self) {
@@ -332,6 +339,10 @@ impl LoraWorker {
             .unwrap_or(Ok(JsValue::NULL))
     }
 
+    pub fn tensor_info(&self) -> Result<JsValue, serde_wasm_bindgen::Error> {
+        serde_wasm_bindgen::to_value(&self.file.tensor_info())
+    }
+
     pub fn effective_scales_all(&self) -> Result<JsValue, JsValue> {
         console_error_panic_hook::set_once();
         let scales = self.file.effective_scales_all();
@@ -391,6 +402,7 @@ mod tests {
 
         let mut worker =
             LoraWorker::new_from_buffer(&buffer, "boo.safetensors").expect("load from buffer");
+        worker.reload_from_buffer(&buffer);
 
         let _ = worker
             .scale_weight("lora_unet_down_blocks_1_resnets_1_conv2")
@@ -415,6 +427,7 @@ mod tests {
             "lora_unet_down_blocks_1_resnets_1_conv2.safetensors",
         )
         .expect("load from buffer");
+        worker.reload_from_buffer(&buffer);
 
         worker.scale_weights();
 
@@ -435,6 +448,51 @@ mod tests {
             LoraWorker::new_from_buffer(&buffer, "boo.safetensors").expect("load from buffer");
 
         assert_eq!(worker.base_names().len(), 264);
+    }
+
+    #[wasm_bindgen_test]
+    async fn header_only_constructor_exposes_keys_without_loading_weights() {
+        wasm_bindgen_test_configure!(run_in_browser);
+        let buffer = load_test_file(file("boo.safetensors").as_str())
+            .await
+            .unwrap();
+
+        let mut len_bytes = [0u8; 8];
+        len_bytes.copy_from_slice(&buffer[0..8]);
+        let header_len = u64::from_le_bytes(len_bytes) as usize;
+        let header_only = &buffer[0..8 + header_len];
+
+        let worker = LoraWorker::new_from_buffer(header_only, "boo.safetensors")
+            .expect("load from header buffer");
+
+        assert!(!worker.is_tensors_loaded());
+        assert!(!worker.keys().is_empty());
+        assert!(!worker.base_names().is_empty());
+        assert!(worker.tensor_info().is_ok());
+    }
+
+    #[wasm_bindgen_test]
+    async fn reload_from_buffer_loads_weights_after_header_only_construction() {
+        wasm_bindgen_test_configure!(run_in_browser);
+        let buffer = load_test_file(file("boo.safetensors").as_str())
+            .await
+            .unwrap();
+
+        let mut len_bytes = [0u8; 8];
+        len_bytes.copy_from_slice(&buffer[0..8]);
+        let header_len = u64::from_le_bytes(len_bytes) as usize;
+        let header_only = &buffer[0..8 + header_len];
+
+        let mut worker = LoraWorker::new_from_buffer(header_only, "boo.safetensors")
+            .expect("load from header buffer");
+        assert!(!worker.is_tensors_loaded());
+
+        worker.reload_from_buffer(&buffer);
+        assert!(worker.is_tensors_loaded());
+
+        assert!(worker
+            .scale_weight("lora_unet_down_blocks_1_attentions_0_transformer_blocks_0_attn2_to_k")
+            .is_ok());
     }
 
     #[wasm_bindgen_test]
@@ -496,8 +554,9 @@ mod tests {
             .await
             .unwrap();
 
-        let worker =
+        let mut worker =
             LoraWorker::new_from_buffer(&buffer, "boo.safetensors").expect("load from buffer");
+        worker.reload_from_buffer(&buffer);
 
         assert_eq!(worker.alphas().len(), 1);
     }
@@ -509,8 +568,9 @@ mod tests {
             .await
             .unwrap();
 
-        let worker =
+        let mut worker =
             LoraWorker::new_from_buffer(&buffer, "boo.safetensors").expect("load from buffer");
+        worker.reload_from_buffer(&buffer);
 
         assert_eq!(worker.alphas().len(), 1);
     }
@@ -550,6 +610,7 @@ mod tests {
 
         let mut worker =
             LoraWorker::new_from_buffer(&buffer, "boo.safetensors").expect("load from buffer");
+        worker.reload_from_buffer(&buffer);
 
         assert!(worker
             .scale_weight("lora_unet_up_blocks_3_attentions_2_transformer_blocks_0_attn1_to_k")
@@ -570,6 +631,7 @@ mod tests {
 
         let mut worker =
             LoraWorker::new_from_buffer(&buffer, "boo.safetensors").expect("load from buffer");
+        worker.reload_from_buffer(&buffer);
 
         assert!(worker
             .scale_weight("lora_unet_down_blocks_1_attentions_0_transformer_blocks_0_attn2_to_k")
@@ -597,6 +659,7 @@ mod tests {
 
         let mut worker =
             LoraWorker::new_from_buffer(&buffer, "boo.safetensors").expect("load from buffer");
+        worker.reload_from_buffer(&buffer);
 
         assert!(worker
             .scale_weight("lora_unet_down_blocks_1_attentions_0_transformer_blocks_0_attn2_to_k")
@@ -659,8 +722,9 @@ mod tests {
             .await
             .unwrap();
 
-        let worker = LoraWorker::new_from_buffer(&buffer, "Pixel Sorting.safetensors")
+        let mut worker = LoraWorker::new_from_buffer(&buffer, "Pixel Sorting.safetensors")
             .expect("load from buffer");
+        worker.reload_from_buffer(&buffer);
 
         for base_name in worker.base_names().into_iter().take(2) {
             let norms = worker.norms(


### PR DESCRIPTION
## Summary
- Fixes an `invalid malloc request` crash when uploading large (2GB+) LoRA `.safetensors` files to the browser WASM inspector, caused by copying the whole file into wasm32 linear memory (4GB ceiling) just to read metadata.
- Upload now parses only the safetensors header (8-byte length prefix + JSON tensor index); tensor weight values (norms, scale-weight, rank-metrics, alphas, effective-scale) are loaded on demand only when a user actually requests them, via the existing `reload_from_buffer`/`unload` mechanism.
- Exposes per-tensor name/dtype/shape info (`tensor_info`) to the UI as part of the header parse.
- Fixes two bugs surfaced during review/live testing: the React UI was auto-fetching `alphas` on every file mount (defeating the fix in practice), and duplicate Headline/nav rendering for LoRA files with no `__metadata__` block (e.g. ComfyUI-native LoRAs).

## Test plan
- [x] `cargo test --workspace` — 96 passed, 0 failed (inspector crate)
- [x] `wasm-pack test --headless --firefox` — 20/20 `worker::` tests pass
- [x] `make fmt` clean
- [x] Live-verified via Playwright against the original failing 2.6GB file (`Flux_2-Turbo-LoRA_comfyui.safetensors`): upload succeeds, no crash, tensor list renders, no full-file load triggered on mount
- [x] Live-verified a normal metadata-bearing file (`boo.safetensors`) still renders unaffected

Known follow-up (explicitly out of scope): norms/scale-weight/rank-metrics/alphas still require a full-file load when a user explicitly requests them, so those actions will still hit the memory ceiling on truly huge files. Making weight-derived stats lazy per-tensor end-to-end is a separate, larger project.

AI Assisted